### PR TITLE
[#4] Fixes the extraction when it is zipkin sampling flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and README from the [OpenTracing API](https://github.com/opentracing/opentracing
 
 In order to understand OpenTracing API, one must first be familiar with the [OpenTracing project](http://opentracing.io) and [terminology](http://opentracing.io/spec/) more generally.
 
-To understand how Zipkin and Brave work, you can look at [Zipkin Architecture](http://zipkin.io/pages/architecture.html) and [Zipkin Api](https://github.com/jcchavezs/zipkin-php) documentation.
+To understand how Zipkin work, you can look at [Zipkin Architecture](http://zipkin.io/pages/architecture.html) and [Zipkin Api](https://github.com/jcchavezs/zipkin-php) documentation.
 
 ### Installation
 
@@ -39,8 +39,7 @@ use Zipkin\TracingBuilder;
 use Zipkin\Reporters\Http;
 
 $endpoint = Endpoint::create('my_service', '127.0.0.1', null, 8081);
-$clientFactory = CurlFactory::create();
-$reporter = new Zipkin\Reporters\Http($clientFactory, $logger);
+$reporter = new Zipkin\Reporters\Http();
 $sampler = BinarySampler::createAsAlwaysSample();
 $tracing = TracingBuilder::create()
 	->havingLocalEndpoint($endpoint)

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "opentracing/opentracing": "1.0.0-beta2",
-        "jcchavezs/zipkin": "1.0.0-beta5"
+        "jcchavezs/zipkin": "1.0.0-beta7"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7.19",
@@ -17,7 +17,7 @@
             "email": "jcchavezs@gmail.com"
         }
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
             "ZipkinOpenTracing\\": "./src/ZipkinOpenTracing/"
@@ -25,8 +25,11 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "ZipkinOpenTracingTests\\": "./tests/"
+            "ZipkinOpenTracing\\Tests\\": "./tests/"
         }
+    },
+    "provide": {
+        "opentracing/opentracing": "dev-master"
     },
     "scripts": {
         "test": "./vendor/bin/phpunit tests",

--- a/src/ZipkinOpenTracing/PartialSpanContext.php
+++ b/src/ZipkinOpenTracing/PartialSpanContext.php
@@ -4,26 +4,29 @@ namespace ZipkinOpenTracing;
 
 use ArrayIterator;
 use OpenTracing\SpanContext as OTSpanContext;
-use Zipkin\Propagation\TraceContext;
+use Zipkin\Propagation\SamplingFlags;
 
-final class SpanContext implements OTSpanContext, WrappedTraceContext
+/**
+ * Used to wrap SamplingFlags coming from extractor
+ */
+final class PartialSpanContext implements OTSpanContext, WrappedTraceContext
 {
-    private $traceContext;
+    private $samplingFlags;
     private $baggageItems;
 
-    private function __construct(TraceContext $traceContext, array $baggageItems = [])
+    private function __construct(SamplingFlags $samplingFlags, array $baggageItems = [])
     {
-        $this->traceContext = $traceContext;
+        $this->samplingFlags = $samplingFlags;
         $this->baggageItems = $baggageItems;
     }
 
     /**
-     * @param TraceContext $traceContext
-     * @return SpanContext
+     * @param SamplingFlags $samplingFlags
+     * @return PartialSpanContext
      */
-    public static function fromTraceContext(TraceContext $traceContext)
+    public static function fromSamplingFlags(SamplingFlags $samplingFlags)
     {
-        return new self($traceContext);
+        return new self($samplingFlags);
     }
 
     /**
@@ -47,7 +50,7 @@ final class SpanContext implements OTSpanContext, WrappedTraceContext
      */
     public function withBaggageItem($key, $value)
     {
-        return new self($this->traceContext, [$key => $value] + $this->baggageItems);
+        return new self($this->samplingFlags, [$key => $value] + $this->baggageItems);
     }
 
     /**
@@ -55,6 +58,6 @@ final class SpanContext implements OTSpanContext, WrappedTraceContext
      */
     public function getContext()
     {
-        return $this->traceContext;
+        return $this->samplingFlags;
     }
 }

--- a/src/ZipkinOpenTracing/Span.php
+++ b/src/ZipkinOpenTracing/Span.php
@@ -4,8 +4,8 @@ namespace ZipkinOpenTracing;
 
 use OpenTracing\Ext\Tags;
 use OpenTracing\Span as OTSpan;
-use Zipkin\Span as ZipkinSpan;
 use OpenTracing\SpanContext;
+use Zipkin\Span as ZipkinSpan;
 use Zipkin\Timestamp;
 use ZipkinOpenTracing\SpanContext as ZipkinOpenTracingContext;
 

--- a/src/ZipkinOpenTracing/WrappedTraceContext.php
+++ b/src/ZipkinOpenTracing/WrappedTraceContext.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ZipkinOpenTracing;
+
+use Zipkin\Propagation\SamplingFlags;
+
+interface WrappedTraceContext
+{
+    /**
+     * @return SamplingFlags
+     */
+    public function getContext();
+}

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ZipkinOpenTracingTests\Unit;
+namespace ZipkinOpenTracing\Tests\Unit;
 
 use PHPUnit_Framework_TestCase;
 use Zipkin\Propagation\DefaultSamplingFlags;

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace ZipkinOpenTracing\Tests\Unit;
+
+use PHPUnit_Framework_TestCase;
+use Zipkin\Propagation\DefaultSamplingFlags;
+use Zipkin\TracingBuilder;
+use ZipkinOpenTracing\PartialSpanContext;
+use ZipkinOpenTracing\SpanContext;
+use ZipkinOpenTracing\Tracer;
+use OpenTracing\Formats;
+use Zipkin\Propagation\TraceContext;
+
+final class TracerTest extends PHPUnit_Framework_TestCase
+{
+    const TEST_TRACE_ID = '48485a3953bb6124';
+    const TEST_SPAN_ID = '48485a3953bb6125';
+    const TEST_SAMPLED = '1';
+    const TEST_DEBUG = '1';
+
+    public function testExtractOfSamplingFlagsSuccess()
+    {
+        $tracing = TracingBuilder::create()->build();
+        $tracer = new Tracer($tracing);
+        $extractedContext = $tracer->extract(Formats\TEXT_MAP, [
+            'x-b3-sampled' => self::TEST_SAMPLED,
+            'x-b3-flags' => self::TEST_DEBUG,
+        ]);
+
+        $this->assertTrue($extractedContext instanceof PartialSpanContext);
+        $this->assertTrue(
+            $extractedContext->getContext()->isEqual(
+                DefaultSamplingFlags::create(self::TEST_SAMPLED === '1', self::TEST_DEBUG === '1')
+            )
+        );
+    }
+
+    public function testExtractOfTraceContextSuccess()
+    {
+        $tracing = TracingBuilder::create()->build();
+        $tracer = new Tracer($tracing);
+        $extractedContext = $tracer->extract(Formats\TEXT_MAP, [
+            'x-b3-traceid' => self::TEST_TRACE_ID,
+            'x-b3-spanid' => self::TEST_SPAN_ID,
+            'x-b3-sampled' => self::TEST_SAMPLED,
+            'x-b3-flags' => self::TEST_DEBUG,
+        ]);
+
+        $this->assertTrue($extractedContext instanceof SpanContext);
+        $this->assertTrue(
+            $extractedContext->getContext()->isEqual(TraceContext::create(
+                self::TEST_TRACE_ID,
+                self::TEST_SPAN_ID,
+                null,
+                self::TEST_SAMPLED === '1',
+                self::TEST_DEBUG === '1'
+            ))
+        );
+    }
+}


### PR DESCRIPTION
This PR allows OpenTracing implementation to deal with `SamplingFlags` as `PartialSpanContext`.

Ping @niborb @adriancole @beberlei

Closes #4 