### PR TITLE
Allow HTTP Headers in Tracer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,93 @@
 composer.lock
 vendor/
+
+# Created by https://www.gitignore.io/api/intellij+all
+# Edit at https://www.gitignore.io/?templates=intellij+all
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+# End of https://www.gitignore.io/api/intellij+all

--- a/tests/Unit/HeaderClass.php
+++ b/tests/Unit/HeaderClass.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
-class HeaderClass implements RequestInterface
+final class HeaderClass implements RequestInterface
 {
     /** @var array $headers */
     private $headers;

--- a/tests/Unit/HeaderClass.php
+++ b/tests/Unit/HeaderClass.php
@@ -2,7 +2,6 @@
 
 namespace ZipkinOpenTracing\Tests\Unit;
 
-
 use function array_keys;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -10,7 +9,7 @@ use Psr\Http\Message\UriInterface;
 
 class HeaderClass implements RequestInterface
 {
-    /** @param array $headers */
+    /** @var array $headers */
     private $headers;
 
     /** @var array $lowerCaseHeaders */
@@ -73,6 +72,7 @@ class HeaderClass implements RequestInterface
 
     // These functions are required by the interface but no used during
     // parsing of headers
+    // phpcs:disable
     public function getProtocolVersion(){}
     public function withProtocolVersion($version){}
     public function getHeaderLine($name){}
@@ -85,4 +85,5 @@ class HeaderClass implements RequestInterface
     public function withMethod($method){}
     public function getUri(){}
     public function withUri(UriInterface $uri, $preserveHost = false){}
+    // phpcs:enable
 }

--- a/tests/Unit/HeaderClass.php
+++ b/tests/Unit/HeaderClass.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace ZipkinOpenTracing\Tests\Unit;
+
+
+use function array_keys;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+class HeaderClass implements RequestInterface
+{
+    /** @param array $headers */
+    private $headers;
+
+    /** @var array $lowerCaseHeaders */
+    private $lowerCaseHeaders;
+
+    public function __construct(array $headers = [])
+    {
+        $this->headers = $headers;
+        $keys = array_keys($headers);
+        $this->lowerCaseHeaders = [];
+        foreach ($keys as $key) {
+            $this->lowerCaseHeaders[strtolower($key)] = $key;
+        }
+    }
+
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    public function hasHeader($name)
+    {
+        $lowerName = strtolower($name);
+
+        return array_key_exists($lowerName, $this->lowerCaseHeaders);
+    }
+
+    public function getHeader($name)
+    {
+        $lowerName = strtolower($name);
+
+        if (array_key_exists($lowerName, $this->lowerCaseHeaders)) {
+            $index = $this->lowerCaseHeaders[$lowerName];
+
+            return [$this->headers[$index]];
+        } else {
+            return [];
+        }
+    }
+
+    public function withHeader($name, $value)
+    {
+        $this->headers[$name] = $value;
+
+        return $this;
+    }
+
+    public function withAddedHeader($name, $value)
+    {
+        $lowerName = strtolower($name);
+        if (array_key_exists($lowerName, $this->lowerCaseHeaders)) {
+            $index = $this->lowerCaseHeaders[$lowerName];
+            $this->headers[$index] = [$this->headers[$index], $value];
+        } else {
+            $this->headers[$index] = $value;
+        }
+
+        return $this;
+    }
+
+    // These functions are required by the interface but no used during
+    // parsing of headers
+    public function getProtocolVersion(){}
+    public function withProtocolVersion($version){}
+    public function getHeaderLine($name){}
+    public function withoutHeader($name){}
+    public function getBody(){}
+    public function withBody(StreamInterface $body){}
+    public function getRequestTarget(){}
+    public function withRequestTarget($requestTarget){}
+    public function getMethod(){}
+    public function withMethod($method){}
+    public function getUri(){}
+    public function withUri(UriInterface $uri, $preserveHost = false){}
+}

--- a/tests/Unit/HeaderClass.php
+++ b/tests/Unit/HeaderClass.php
@@ -9,10 +9,14 @@ use Psr\Http\Message\UriInterface;
 
 final class HeaderClass implements RequestInterface
 {
-    /** @var array $headers */
+    /**
+     * @var array $headers
+     */
     private $headers;
 
-    /** @var array $lowerCaseHeaders */
+    /**
+     * @var array $lowerCaseHeaders
+     */
     private $lowerCaseHeaders;
 
     public function __construct(array $headers = [])

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -127,4 +127,29 @@ final class TracerTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expectedSpan, $actualSpan);
     }
+
+    public function testExtractContextHeaderSuccess()
+    {
+        $tracing = TracingBuilder::create()->build();
+        $tracer = new Tracer($tracing);
+        $headers = new HeaderClass([
+            'x-b3-traceid' => self::TRACE_ID,
+            'x-b3-spanid' => self::SPAN_ID,
+            'x-b3-sampled' => self::SAMPLED,
+            'x-b3-flags' => self::DEBUG,
+        ]);
+        $extractedContext = $tracer->extract(Formats\HTTP_HEADERS, $headers);
+
+        $this->assertTrue($extractedContext instanceof SpanContext);
+        $this->assertTrue(
+            $extractedContext->getContext()->isEqual(TraceContext::create(
+                self::TRACE_ID,
+                self::SPAN_ID,
+                null,
+                self::SAMPLED === '1',
+                self::DEBUG === '1'
+            ))
+        );
+    }
+
 }

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -151,5 +151,4 @@ final class TracerTest extends PHPUnit_Framework_TestCase
             ))
         );
     }
-
 }


### PR DESCRIPTION
This adds support for HTTP Headers when extracting and injecting the
context.  To use, the carrier needs to implement the
`RequestInterface` interface.

Issue: #22