### PR TITLE
Update zipkin-php to the latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A Zipkin bridge with OpenTracing",
     "type": "library",
     "require": {
-        "openzipkin/zipkin": "1.1.1",
+        "openzipkin/zipkin": "^1.3.4",
         "opentracing/opentracing": "1.0.0-beta5"
     },
     "require-dev": {


### PR DESCRIPTION
Is it ok to upgrade zipkin dependency to the latest version? I need to access the version with https://github.com/openzipkin/zipkin-php/issues/76#issue-334247322 resolved.