### PR TITLE
Support further opentracing lib versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: php
 
 php:
-  - '5.6'
-  - '7.0'
-  - '7.1'
-  - '7.2'
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 install:
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "openzipkin/zipkin": "^1.3.4",
-        "opentracing/opentracing": "1.0.0-beta5"
+        "opentracing/opentracing": "^1@beta"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7.19",

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "A Zipkin bridge with OpenTracing",
     "type": "library",
     "require": {
+        "php": "~5.6 || ~7.0",
         "openzipkin/zipkin": "^1.3.4",
         "opentracing/opentracing": "^1@beta"
     },

--- a/src/ZipkinOpenTracing/ScopeManager.php
+++ b/src/ZipkinOpenTracing/ScopeManager.php
@@ -15,7 +15,7 @@ final class ScopeManager implements OTScopeManager
     /**
      * {@inheritdoc}
      */
-    public function activate(OTSpan $span, $finishSpanOnClose)
+    public function activate(OTSpan $span, $finishSpanOnClose = true)
     {
         $this->active = new Scope($this, $span, $finishSpanOnClose);
 


### PR DESCRIPTION
Current the library sticks to `1.0.0-beta5`, but looks like there are no reasons to not support newer betas/future stable releases