### PR TITLE
fix: fixes the injection for a noop span.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "library",
     "require": {
         "php": "~5.6 || ~7.0",
-        "openzipkin/zipkin": "^1.3.4",
-        "opentracing/opentracing": "^1@beta"
+        "openzipkin/zipkin": "^1.3.6",
+        "opentracing/opentracing": "1.0.0-beta5"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7.19",

--- a/src/ZipkinOpenTracing/NoopSpan.php
+++ b/src/ZipkinOpenTracing/NoopSpan.php
@@ -37,66 +37,36 @@ final class NoopSpan implements OTSpan
     }
 
     /**
-     * Yields the SpanContext for this Span. Note that the return value of
-     * Span::getContext() is still valid after a call to Span::finish(), as is
-     * a call to Span::getContext() after a call to Span::finish().
-     *
-     * @return SpanContext
+     * {@inheritdoc}
      */
     public function getContext()
     {
-        return NoopSpanContext::create($this->context->getContext());
+        return $this->context;
     }
 
     /**
-     * Sets the end timestamp and finalizes Span state.
-     *
-     * With the exception of calls to Context() (which are always allowed),
-     * finish() must be the last call made to any span instance, and to do
-     * otherwise leads to undefined behavior
-     *
-     * If the span is already finished, a warning should be logged.
-     *
-     * @param float|int|\DateTimeInterface|null $finishTime if passing float or int
-     * it should represent the timestamp (including as many decimal places as you need)
-     * @param array $logRecords
+     * {@inheritdoc}
      */
     public function finish($finishTime = null, array $logRecords = [])
     {
     }
 
     /**
-     * If the span is already finished, a warning should be logged.
-     *
-     * @param string $newOperationName
+     * {@inheritdoc}
      */
     public function overwriteOperationName($newOperationName)
     {
     }
 
     /**
-     * Sets tags to the Span in key:value format, key must be a string and tag must be either
-     * a string, a boolean value, or a numeric type.
-     *
-     * As an implementor, consider using "standard tags" listed in {@see \OpenTracing\Ext\Tags}
-     *
-     * If the span is already finished, a warning should be logged.
-     *
-     * @param string $key
-     * @param string $value
+     * {@inheritdoc}
      */
     public function setTag($key, $value)
     {
     }
 
     /**
-     * Adds a log record to the span in key:value format, key must be a string and tag must be either
-     * a string, a boolean value, or a numeric type.
-     *
-     * If the span is already finished, a warning should be logged.
-     *
-     * @param array $fields
-     * @param int|float|\DateTimeInterface $timestamp
+     * {@inheritdoc}
      */
     public function log(array $fields = [], $timestamp = null)
     {

--- a/src/ZipkinOpenTracing/NoopSpanContext.php
+++ b/src/ZipkinOpenTracing/NoopSpanContext.php
@@ -6,6 +6,12 @@ use ArrayIterator;
 use OpenTracing\SpanContext as OTSpanContext;
 use Zipkin\Propagation\TraceContext;
 
+/**
+ * @deprecated
+ *
+ * This shouldn't have been introduced as propagation expects an actual
+ * context not a noop one.
+ */
 class NoopSpanContext implements OTSpanContext, WrappedTraceContext
 {
     /**

--- a/tests/Unit/Request.php
+++ b/tests/Unit/Request.php
@@ -2,6 +2,7 @@
 
 namespace ZipkinOpenTracing\Tests\Unit;
 
+use LogicException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
@@ -9,67 +10,56 @@ use Psr\Http\Message\UriInterface;
 final class Request implements RequestInterface
 {
     /**
-     * @var array $headers
+     * @var array
      */
     private $headers;
 
-    /**
-     * @var array $lowerCaseHeaders
-     */
-    private $lowerCaseHeaders;
-
     public function __construct(array $headers = [])
     {
-        $this->headers = $headers;
-        $keys = \array_keys($headers);
-        $this->lowerCaseHeaders = [];
-        foreach ($keys as $key) {
-            $this->lowerCaseHeaders[strtolower($key)] = $key;
+        foreach ($headers as $key => $value) {
+            $this->headers[strtolower($key)] = [$value];
         }
     }
 
+    /**
+     *  @return string[][]
+     */
     public function getHeaders()
     {
         return $this->headers;
     }
 
+    /**
+     * @return bool
+     */
     public function hasHeader($name)
     {
-        $lowerName = strtolower($name);
+        foreach ($this->headers as $key => $value) {
+            if ($key === strtolower($name)) {
+                return true;
+            }
+        }
 
-        return \array_key_exists($lowerName, $this->lowerCaseHeaders);
+        return false;
     }
 
+    /**
+     * @return string[]
+     */
     public function getHeader($name)
     {
-        $lowerName = strtolower($name);
-
-        if (\array_key_exists($lowerName, $this->lowerCaseHeaders)) {
-            $index = $this->lowerCaseHeaders[$lowerName];
-
-            return [$this->headers[$index]];
-        } else {
-            return [];
+        foreach ($this->headers as $key => $value) {
+            if ($key === strtolower($name)) {
+                return $value;
+            }
         }
+
+        return [];
     }
 
     public function withHeader($name, $value)
     {
-        $this->headers[$name] = $value;
-
-        return $this;
-    }
-
-    public function withAddedHeader($name, $value)
-    {
-        $lowerName = strtolower($name);
-        if (\array_key_exists($lowerName, $this->lowerCaseHeaders)) {
-            $index = $this->lowerCaseHeaders[$lowerName];
-            $this->headers[$index] = [$this->headers[$index], $value];
-        } else {
-            $this->headers[$index] = $value;
-        }
-
+        $this->headers[strtolower($name)] = [$value];
         return $this;
     }
 
@@ -77,41 +67,69 @@ final class Request implements RequestInterface
     // parsing of headers
     //
     // phpcs:disable
+    public function withAddedHeader($name, $value)
+    {
+        throw new LogicException('not implemented');
+    }
+
     public function getProtocolVersion()
     {
+        throw new LogicException('not implemented');
     }
+
     public function withProtocolVersion($version)
     {
+        throw new LogicException('not implemented');
     }
+
     public function getHeaderLine($name)
     {
+        throw new LogicException('not implemented');
     }
+
     public function withoutHeader($name)
     {
+        throw new LogicException('not implemented');
     }
+
     public function getBody()
     {
+        throw new LogicException('not implemented');
     }
+
     public function withBody(StreamInterface $body)
     {
+        throw new LogicException('not implemented');
     }
+
     public function getRequestTarget()
     {
+        throw new LogicException('not implemented');
     }
+
     public function withRequestTarget($requestTarget)
     {
+        throw new LogicException('not implemented');
     }
+
     public function getMethod()
     {
+        throw new LogicException('not implemented');
     }
+
     public function withMethod($method)
     {
+        throw new LogicException('not implemented');
     }
+
     public function getUri()
     {
+        throw new LogicException('not implemented');
     }
+
     public function withUri(UriInterface $uri, $preserveHost = false)
     {
+        throw new LogicException('not implemented');
     }
     // phpcs:enable
 }


### PR DESCRIPTION
This PR fixes a bug for which NOOP span did not have context information (aka NOOP Context) and hence the injection was throwing an exception. With this change NOOP spans do have trace information and injection can be done successfully.

Replaces https://github.com/jcchavezs/zipkin-php-opentracing/pull/31

Ping @Reasno 