### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/Unit/ScopeManagerTest.php
+++ b/tests/Unit/ScopeManagerTest.php
@@ -13,7 +13,7 @@ final class ScopeManagerTest extends TestCase
      */
     private $manager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->manager = new ScopeManager();
     }


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/7.5/fixtures.html#more-setup-than-teardown), it should be the `protected function setUp(): void` method.