### PR TITLE
chore: removes Zipkin PHP 2.0 as dep.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.4|8.0",
         "opentracing/opentracing": "^1.0.1",
-        "openzipkin/zipkin": "^2.0.2|3.0.x-dev"
+        "openzipkin/zipkin": "3.0.x-dev"
     },
     "provide": {
         "opentracing/opentracing": "dev-master"


### PR DESCRIPTION
We are moving towards Zipkin PHP 3.0 so we don't need 2.0 anymore due to PHP version restrictions.