### PR TITLE
chore: uses Zipkin PHP 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,21 +12,16 @@
     "require": {
         "php": ">=7.4 || ^8.0",
         "opentracing/opentracing": "^1.0.1",
-        "openzipkin/zipkin": "3.0.x-dev"
+        "openzipkin/zipkin": "3.0.0"
     },
     "provide": {
-        "opentracing/opentracing": "dev-master"
+        "opentracing/opentracing": "1.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "3.*",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^0.12.26"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.0.x-dev"
-        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR uses the new Zipkin PHP 3.0 in this library. This is last step before releasing 2.0 in this library.

Ping @limingxinleo 