### PR TITLE
Added PHP 8.4 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ["7.4", "8.0", "8.1", "8.2"]
+        php-versions: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:

--- a/src/ZipkinOpenTracing/Span.php
+++ b/src/ZipkinOpenTracing/Span.php
@@ -23,7 +23,7 @@ final class Span implements OTSpan
 
     private array $remoteEndpointArgs;
 
-    private function __construct($operationName, ZipkinSpan $span, array $remoteEndpointArgs = null)
+    private function __construct($operationName, ZipkinSpan $span, ?array $remoteEndpointArgs = null)
     {
         $this->operationName = $operationName;
         $this->span = $span;
@@ -33,7 +33,7 @@ final class Span implements OTSpan
             $remoteEndpointArgs : ['', null, null, null];
     }
 
-    public static function create(string $operationName, ZipkinSpan $span, array $remoteEndpointArgs = null): Span
+    public static function create(string $operationName, ZipkinSpan $span, ?array $remoteEndpointArgs = null): Span
     {
         return new self($operationName, $span, $remoteEndpointArgs);
     }


### PR DESCRIPTION
Addresses deprecation of implicit nullable parameter declarations (https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)